### PR TITLE
Handle usfm blank lines before the Book ID USFM Marker + misc cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/usfm
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -39,3 +39,26 @@ There are of course other programs that convert usfm to osis. Here are the ones 
 # cu2o
 
 This is a simple wrapper for u2o.py that will allow processing of usfm files that are concatenated into a single file. Consider it experimental. Note that it *requires* u2o in order to work.
+
+#USAGE 
+
+```
+usage: u2o.py [-h] [-d] [-e encoding] [-o output_file] [-l LANG] [-s {canonical,none}] [-v] [-x] [-n] workid filename [filename ...]
+
+convert USFM bibles to OSIS.
+
+positional arguments:
+  workid               work id to use for OSIS file
+  filename             file or files to process (wildcards allowed)
+
+options:
+  -h, --help           show this help message and exit
+  -d                   debug mode (default: False)
+  -e encoding          set encoding to use for USFM files (default: None)
+  -o output_file       specify output file (default: None)
+  -l LANG              specify langauge code (default: und)
+  -s {canonical,none}  sort order (default: canonical)
+  -v                   verbose output (default: False)
+  -x                   disable OSIS validation and reformatting (default: False)
+  -n                   disable unicode NFC normalization (default: False)
+```

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ There are of course other programs that convert usfm to osis. Here are the ones 
 
 This is a simple wrapper for u2o.py that will allow processing of usfm files that are concatenated into a single file. Consider it experimental. Note that it *requires* u2o in order to work.
 
-#USAGE 
+# USAGE 
 
 ```
 usage: u2o.py [-h] [-d] [-e encoding] [-o output_file] [-l LANG] [-s {canonical,none}] [-v] [-x] [-n] workid filename [filename ...]

--- a/output/.gitignore
+++ b/output/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/tests/osis_tests.py
+++ b/tests/osis_tests.py
@@ -1,0 +1,20 @@
+import unittest
+import subprocess
+import re
+import os
+
+class TestOsisGeneration(unittest.TestCase):
+    
+    # run u2o.py 
+    # test osis file is created in output directory
+    # There is no mention of \id markers in stdout
+    def test_osis_file_is_created(self):
+        result = subprocess.run(['python', 'u2o.py', 'TESTID', 'tests/test_data/1cor.usfm'], stdout=subprocess.PIPE)
+        file_path = 'output/TESTID.osis'
+        self.assertTrue(os.path.exists(file_path))
+        self.assertEqual(result.stdout.decode(), '')
+        self.assertNotRegex(result.stdout.decode(), re.escape('\id'))        
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_data/1cor.usfm
+++ b/tests/test_data/1cor.usfm
@@ -1,0 +1,52 @@
+﻿
+\id 1CO - Berean Study Bible
+\h 1 Corinthians
+\toc1 1 Corinthians
+\mt1 1 Corinthians
+\c 1
+\m 
+\v 1 Paul, called to be an apostle of Christ Jesus by the will of God, and our brother Sosthenes, 
+\m 
+\v 2 To the church of God in Corinth, to those sanctified in Christ Jesus and called to be holy, together with all those everywhere who call on the name of our Lord Jesus Christ, their Lord and ours: 
+\m 
+\v 3 Grace and peace to you from God our Father and the Lord Jesus Christ. 
+\m 
+\v 4 I always thank my God for you because of the grace He has given you in Christ Jesus. 
+\v 5 For in Him you have been enriched in every way, in all speech and all knowledge, 
+\v 6 because our testimony about Christ was confirmed in you. 
+\m 
+\v 7 Therefore you do not lack any spiritual gift as you eagerly await the revelation of our Lord Jesus Christ. 
+\v 8 He will sustain you to the end, so that you will be blameless on the day of our Lord Jesus Christ. 
+\v 9 God, who has called you into fellowship with His Son Jesus Christ our Lord, is faithful. 
+\m 
+\v 10 I appeal to you, brothers, in the name of our Lord Jesus Christ, that all of you agree together, so that there may be no divisions among you and that you may be united in mind and conviction. 
+\v 11 My brothers, some from Chloe’s household have informed me that there are quarrels among you. 
+\v 12 What I mean is this: Individuals among you are saying, “I follow Paul,” “I follow Apollos,” “I follow Cephas,”\f + \fr 1:12 \ft That is, Peter\f* or “I follow Christ.” 
+\m 
+\v 13 Is Christ divided? Was Paul crucified for you? Were you baptized into the name of Paul? 
+\v 14 I thank God that I did not baptize any of you except Crispus and Gaius, 
+\v 15 so no one can say that you were baptized into my name. 
+\v 16 Yes, I also baptized the household of Stephanas; beyond that I do not remember if I baptized anyone else. 
+\v 17 For Christ did not send me to baptize, but to preach the gospel, not with words of wisdom, lest the cross of Christ be emptied of its power. 
+\m 
+\v 18 For the message of the cross is foolishness to those who are perishing, but to us who are being saved it is the power of God. 
+\v 19 For it is written: 
+\q1 “I will destroy the wisdom of the wise; 
+\q2 the intelligence of the intelligent I will frustrate.”\f + \fr 1:19 \ft Isaiah 29:14 (see also LXX)\f* 
+\m 
+\v 20 Where is the wise man? Where is the scribe? Where is the philosopher of this age? Has not God made foolish the wisdom of the world? 
+\v 21 For since in the wisdom of God the world through its wisdom did not know Him, God was pleased through the foolishness of what was preached to save those who believe. 
+\m 
+\v 22 Jews demand signs and Greeks search for wisdom, 
+\v 23 but we preach Christ crucified, a stumbling block to Jews and foolishness to Gentiles,\f + \fr 1:23 \ft BYZ and TR to Greeks\f* 
+\v 24 but to those who are called, both Jews and Greeks, Christ the power of God and the wisdom of God. 
+\m 
+\v 25 For the foolishness of God is wiser than man’s wisdom,\f + \fr 1:25 \ft Literally than men; twice in this verse\f* and the weakness of God is stronger than man’s strength. 
+\m 
+\v 26 Brothers, consider the time of your calling: Not many of you were wise by human standards; not many were powerful; not many were of noble birth. 
+\v 27 But God chose the foolish things of the world to shame the wise; God chose the weak things of the world to shame the strong. 
+\v 28 He chose the lowly and despised things of the world, and the things that are not, to nullify the things that are, 
+\v 29 so that no one may boast in His presence. 
+\m 
+\v 30 It is because of Him that you are in Christ Jesus, who has become for us wisdom from God: our righteousness, holiness, and redemption. 
+\v 31 Therefore, as it is written: “Let him who boasts boast in the Lord.”\f + \fr 1:31 \ft Jeremiah 9:24\f* 

--- a/u2o.py
+++ b/u2o.py
@@ -3274,7 +3274,7 @@ def processfiles(
     osisdoc = osisdoc.encode("utf-8")
 
     # write doc to file
-    outfile = f"{workid}.osis"
+    outfile = f"./output/{workid}.osis"
     if outputfile is not None:
         outfile = outputfile
     with open(outfile, "wb") as ofile:

--- a/u2o.py
+++ b/u2o.py
@@ -1608,7 +1608,7 @@ def reflow(flowtext: str) -> str:
 
 def getbookid(text: str) -> Optional[str]:
     """Get book id from file text."""
-    lines = [_ for _ in text.split("\n") if _.startswith("\\id ")]
+    lines = [_ for _ in text.split("\n") if _.lstrip().startswith("\\id ")]
     try:
         bookid = lines[0].split()[1].strip()
     except IndexError:
@@ -2961,8 +2961,9 @@ def convert_to_osis(text: str, bookid: str = "TEST") -> Tuple[str, ...]:
 
     # ---------------------------------------------------------------------- #
 
-    # split text into lines for processing
+    # split text into lines for processing, strip leading spaces
     lines = text.split("\n")
+    lines = [_.lstrip() for _ in lines]
 
     # mark introduction endings...
     for _ in [r"\ib", r"\ie", r"\il", r"\im", r"\io", r"\ip", r"\iq", r"\is"]:


### PR DESCRIPTION

A usfm file that has a blank line or extra spaces before the \id marker will cause the u2o.py script to fail generating the proper XML and revert to a TEST print out and an unused id marker.

Changes:
- Add script usage to README
- Created output directory for generated osis files and gitgnore files
- Created a test and included a sample usfm file that caused the failure
